### PR TITLE
Compilation warning fixes, small bugfixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,14 +52,14 @@ See the comments below.
 Usage:
 ======
 
-In all cases below, the range for t (track number) is 1 through 4096;
+In all cases below, the range for trk (track number) is 1 through 4096;
 
 wavTrigger wTtrig;
 
 **wTrig.start()** - you must call this method first to initialize the serial
   communications.
 
-**wTrig.getVersion(char \*pDst, int len)** - this function will return **len** bytes of
+**wTrig.getVersion(char \*pDst)** - this function will return **VERSION_STRING_LEN** bytes of
   the WAV Trigger version string to the location specified by **pDst**. The function
   returns TRUE if successful, and FALSE if the string is not available. This
   function requires bi-directional communication with the WAV Trigger.
@@ -91,32 +91,32 @@ wavTrigger wTtrig;
   hear the result immediately. If audio is not playing, the new sample-rate offset
   will be used the next time a track is started.
 
-**wTrig.trackPlaySolo(int t)** - this function stops any and all tracks that are
+**wTrig.trackPlaySolo(int trk)** - this function stops any and all tracks that are
   currently playing and starts track number **t** from the beginning.
 
-**wTrig.trackPlayPoly(int t)** - this function starts track number **t** from the
+**wTrig.trackPlayPoly(int trk)** - this function starts track number **t** from the
   beginning, blending it with any other tracks that are currently playing,
   including potentially another copy of the same track.
   
-**wTrig.trackLoad(int t)** - this function loads track number **t** and pauses it
+**wTrig.trackLoad(int trk)** - this function loads track number **t** and pauses it
   at the beginning of the track. Loading muiltiple tracks and then un-pausing them
   all with resumeAllInSync() function below allows for starting multiple tracks in
   sample sync.
   
-**wTrig.trackStop(int t)** - this function stops track number **t** if it's currently
+**wTrig.trackStop(int trk)** - this function stops track number **t** if it's currently
   playing. If track t is not playing, this function does nothing. No other
   tracks are affected.
   
-**wTrig.trackPause(int t)** - this function pauses track number **t** if it's currently
+**wTrig.trackPause(int trk)** - this function pauses track number **t** if it's currently
   playing. If track t is not playing, this function does nothing. Keep in mind
   that a paused track is still using one of the 8 voice slots. A voice allocated
   to playing a track becomes free only when that sound is stopped or the track
   reaches the end of the file (and is not looping).
   
-**wTrig.trackResume(int t)** - this function resumes track number **t** if it's currently
+**wTrig.trackResume(int trk)** - this function resumes track number **t** if it's currently
   paused. If track number **t** is not paused, this function does nothing.
   
-**wTrig.trackLoop(int t, bool enable)** - this function enables (true) or disables
+**wTrig.trackLoop(int trk, bool enable)** - this function enables (true) or disables
   (false) the loop flag for track **t**. This command does not actually start a track,
   only determines how it behaves once it is playing and reaches the end. If the
   loop flag is set, that track will loop continuously until it's stopped, in which
@@ -124,7 +124,7 @@ wavTrigger wTtrig;
   flag is cleared, in which case it will stop when it reaches the end of the track.
   This command may be used either before a track is started or while it's playing.
   
-**wTrig.trackGain(int t, int gain)** - this function immediately sets the gain of
+**wTrig.trackGain(int trk, int gain)** - this function immediately sets the gain of
   track **t** to the specified value. The range for gain is -70 to +10. A value of
   0 (no gain) plays the track at the nominal value in the wav file. This is the
   default gain for every track until changed. A value of -70 is completely
@@ -145,7 +145,7 @@ wavTrigger wTtrig;
   audio buffer. Any tracks that were loaded using the trackLoad() function will start
   and remain sample locked (in sample sync) with one another.
 
-**wTrig.trackFade(int t, int gain, int time, bool stopFlag)** - this command initiates
+**wTrig.trackFade(int trk, int gain, int time, bool stopFlag)** - this command initiates
   a hardware volume fade on track number **t** if it is currently playing. The track
   volume will transition smoothly from the current value to the target gain in the
   specified number of milliseconds. If the stopFlag is non-zero, the track will be
@@ -172,18 +172,18 @@ sketch demonstrates the use of these functions.
 **wTrig.flush()** - This function clears the WAV Trigger communication buffer and resets
   the local track status info.
   
-**wTrig.trackPlaySolo(int t, bool lock)** - this function stops any and all tracks that
+**wTrig.trackPlaySolo(int trk, bool lock)** - this function stops any and all tracks that
   are currently playing and starts track number **t** from the beginning. If **lock** is
   TRUE, the track will not be subject to the WAV Trigger's voice stealing algorithm,
   and will not be stopped if the max number of voices is reached.
 
-**wTrig.trackPlayPoly(int t, bool lock)** - this function starts track number **t** from
+**wTrig.trackPlayPoly(int trk, bool lock)** - this function starts track number **t** from
   the beginning, blending it with any other tracks that are currently playing,
   including potentially another copy of the same track. If **lock** is TRUE, the track will
   not be subject to the WAV Trigger's voice stealing algorithm, and will not be stopped
   if the max number of voices is reached.
   
-**wTrig.trackLoad(int t, bool lock)** - this function loads track number **t** and pauses it
+**wTrig.trackLoad(int trk, bool lock)** - this function loads track number **t** and pauses it
   at the beginning of the track. Loading muiltiple tracks and then un-pausing them
   all with resumeAllInSync() function allows for starting multiple tracks in sample
   sync.  If **lock** is TRUE, the track will not be subject to the WAV Trigger's voice

--- a/README.md
+++ b/README.md
@@ -5,13 +5,7 @@ WAV Trigger Serial Control Arduino Library
 
 Because the UNO's single serial port is used for programming, this library makes use
 of the AltSoftwareSerial library from PJRC by default. If you're using an UNO, you'll
-therefore want to download and install that library as well. Be sure to include both
-library headers at the top of your sketch. (See the example sketches)
-
-```
-#include <AltSoftSerial.h>
-#include <wavTrigger.h>
-```
+therefore want to download and install that library as well.
 
 However, if you're using an Arduino with at least one additional hardware serial
 port, you will not need AltSoftSerial. Instead, just make one small change to the

--- a/examples/WTrigAdvanced/WTrigAdvanced.ino
+++ b/examples/WTrigAdvanced/WTrigAdvanced.ino
@@ -43,7 +43,6 @@
 //    10 to 20 seconds long and have no silence at the start of the file.
 
 #include <Metro.h>
-#include <AltSoftSerial.h>    // Arduino build environment requires this
 #include <wavTrigger.h>
 
 #define LED 13                // our LED

--- a/examples/WTrigAdvanced/WTrigAdvanced.ino
+++ b/examples/WTrigAdvanced/WTrigAdvanced.ino
@@ -92,7 +92,7 @@ void setup() {
   
   // If bi-directional communication is wired up, then we should by now be able
   //  to fetch the version string and number of tracks on the SD card.
-  if (wTrig.getVersion(gWTrigVersion, VERSION_STRING_LEN)) {
+  if (wTrig.getVersion(gWTrigVersion)) {
       Serial.print(gWTrigVersion);
       Serial.print("\n");
       gNumTracks = wTrig.getNumTracks();

--- a/examples/WTrigBasic/WTrigBasic.ino
+++ b/examples/WTrigBasic/WTrigBasic.ino
@@ -41,7 +41,6 @@
 //    to 20 seconds long and have no silence at the start of the file.
 
 #include <Metro.h>
-#include <AltSoftSerial.h>    // Arduino build environment requires this
 #include <wavTrigger.h>
 
 #define LED 13                // our LED

--- a/wavTrigger.cpp
+++ b/wavTrigger.cpp
@@ -228,8 +228,6 @@ int i;
 		return false;
 	}
 	for (i = 0; i < (VERSION_STRING_LEN - 1); i++) {
-		if (i >= (len - 1))
-			break;
 		pDst[i] = version[i];
 	}
 	return true;

--- a/wavTrigger.cpp
+++ b/wavTrigger.cpp
@@ -42,7 +42,6 @@ uint8_t txbuf[5];
 void wavTrigger::flush(void) {
 
 int i;
-uint8_t dat;
 
 	rxCount = 0;
 	rxLen = 0;
@@ -51,7 +50,7 @@ uint8_t dat;
 	  voiceTable[i] = 0xffff;
 	}
 	while(WTSerial.available())
-		dat = WTSerial.read();
+		WTSerial.read();
 }
 
 
@@ -168,7 +167,7 @@ bool fResult = false;
 
 	update();
 	for (i = 0; i < MAX_NUM_VOICES; i++) {
-		if (voiceTable[i] == trk)
+		if (voiceTable[i] == (uint16_t)trk)
 			fResult = true;
 	}
 	return fResult;

--- a/wavTrigger.cpp
+++ b/wavTrigger.cpp
@@ -41,12 +41,10 @@ uint8_t txbuf[5];
 // **************************************************************
 void wavTrigger::flush(void) {
 
-int i;
-
 	rxCount = 0;
 	rxLen = 0;
 	rxMsgReady = false;
-	for (i = 0; i < MAX_NUM_VOICES; i++) {
+	for (int i = 0; i < MAX_NUM_VOICES; i++) {
 	  voiceTable[i] = 0xffff;
 	}
 	while(WTSerial.available())
@@ -57,7 +55,6 @@ int i;
 // **************************************************************
 void wavTrigger::update(void) {
 
-int i;
 uint8_t dat;
 uint8_t voice;
 uint16_t track;
@@ -129,7 +126,7 @@ uint16_t track;
 				break;
 
 				case RSP_VERSION_STRING:
-					for (i = 0; i < (VERSION_STRING_LEN - 1); i++)
+					for (int i = 0; i < (VERSION_STRING_LEN - 1); i++)
 						version[i] = rxMessage[i + 1];
 					version[VERSION_STRING_LEN - 1] = 0;
 					versionRcvd = true;
@@ -148,44 +145,36 @@ uint16_t track;
 					///\Serial.print("Sys info received\n");
 					// ==========================
 				break;
-
 			}
 			rxCount = 0;
 			rxLen = 0;
 			rxMsgReady = false;
-
 		} // if (rxMsgReady)
-
 	} // while (WTSerial.available() > 0)
 }
 
 // **************************************************************
 bool wavTrigger::isTrackPlaying(int trk) {
 
-int i;
-bool fResult = false;
-
 	update();
-	for (i = 0; i < MAX_NUM_VOICES; i++) {
+	for (int i = 0; i < MAX_NUM_VOICES; i++) {
 		if (voiceTable[i] == (uint16_t)trk)
-			fResult = true;
+			return true;
 	}
-	return fResult;
+	return false;
 }
 
 // **************************************************************
 void wavTrigger::masterGain(int gain) {
 
 uint8_t txbuf[7];
-unsigned short vol;
 
 	txbuf[0] = SOM1;
 	txbuf[1] = SOM2;
 	txbuf[2] = 0x07;
 	txbuf[3] = CMD_MASTER_VOLUME;
-	vol = (unsigned short)gain;
-	txbuf[4] = (uint8_t)vol;
-	txbuf[5] = (uint8_t)(vol >> 8);
+	txbuf[4] = (uint8_t)gain;
+	txbuf[5] = (uint8_t)(gain >> 8);
 	txbuf[6] = EOM;
 	WTSerial.write(txbuf, 7);
 }
@@ -221,13 +210,11 @@ uint8_t txbuf[6];
 // **************************************************************
 bool wavTrigger::getVersion(char *pDst) {
 
-int i;
-
 	update();
 	if (!versionRcvd) {
 		return false;
 	}
-	for (i = 0; i < (VERSION_STRING_LEN - 1); i++) {
+	for (int i = 0; i < (VERSION_STRING_LEN - 1); i++) {
 		pDst[i] = version[i];
 	}
 	return true;
@@ -366,7 +353,6 @@ uint8_t txbuf[5];
 void wavTrigger::trackGain(int trk, int gain) {
 
 uint8_t txbuf[9];
-unsigned short vol;
 
 	txbuf[0] = SOM1;
 	txbuf[1] = SOM2;
@@ -374,9 +360,8 @@ unsigned short vol;
 	txbuf[3] = CMD_TRACK_VOLUME;
 	txbuf[4] = (uint8_t)trk;
 	txbuf[5] = (uint8_t)(trk >> 8);
-	vol = (unsigned short)gain;
-	txbuf[6] = (uint8_t)vol;
-	txbuf[7] = (uint8_t)(vol >> 8);
+	txbuf[6] = (uint8_t)gain;
+	txbuf[7] = (uint8_t)(gain >> 8);
 	txbuf[8] = EOM;
 	WTSerial.write(txbuf, 9);
 }
@@ -385,7 +370,6 @@ unsigned short vol;
 void wavTrigger::trackFade(int trk, int gain, int time, bool stopFlag) {
 
 uint8_t txbuf[12];
-unsigned short vol;
 
 	txbuf[0] = SOM1;
 	txbuf[1] = SOM2;
@@ -393,9 +377,8 @@ unsigned short vol;
 	txbuf[3] = CMD_TRACK_FADE;
 	txbuf[4] = (uint8_t)trk;
 	txbuf[5] = (uint8_t)(trk >> 8);
-	vol = (unsigned short)gain;
-	txbuf[6] = (uint8_t)vol;
-	txbuf[7] = (uint8_t)(vol >> 8);
+	txbuf[6] = (uint8_t)gain;
+	txbuf[7] = (uint8_t)(gain >> 8);
 	txbuf[8] = (uint8_t)time;
 	txbuf[9] = (uint8_t)(time >> 8);
 	txbuf[10] = stopFlag;
@@ -407,15 +390,13 @@ unsigned short vol;
 void wavTrigger::samplerateOffset(int offset) {
 
 uint8_t txbuf[7];
-unsigned short off;
 
 	txbuf[0] = SOM1;
 	txbuf[1] = SOM2;
 	txbuf[2] = 0x07;
 	txbuf[3] = CMD_SAMPLERATE_OFFSET;
-	off = (unsigned short)offset;
-	txbuf[4] = (uint8_t)off;
-	txbuf[5] = (uint8_t)(off >> 8);
+	txbuf[4] = (uint8_t)offset;
+	txbuf[5] = (uint8_t)(offset >> 8);
 	txbuf[6] = EOM;
 	WTSerial.write(txbuf, 7);
 }

--- a/wavTrigger.cpp
+++ b/wavTrigger.cpp
@@ -232,7 +232,6 @@ int i;
 			break;
 		pDst[i] = version[i];
 	}
-	pDst[++i] = 0;
 	return true;
 }
 

--- a/wavTrigger.cpp
+++ b/wavTrigger.cpp
@@ -433,5 +433,3 @@ uint8_t txbuf[6];
 	txbuf[5] = EOM;
 	WTSerial.write(txbuf, 6);
 }
-
-

--- a/wavTrigger.cpp
+++ b/wavTrigger.cpp
@@ -219,7 +219,7 @@ uint8_t txbuf[6];
 }
 
 // **************************************************************
-bool wavTrigger::getVersion(char *pDst, int len) {
+bool wavTrigger::getVersion(char *pDst) {
 
 int i;
 

--- a/wavTrigger.h
+++ b/wavTrigger.h
@@ -108,7 +108,7 @@ public:
 	void flush(void);
 	void setReporting(bool enable);
 	void setAmpPwr(bool enable);
-	bool getVersion(char *pDst, int len);
+	bool getVersion(char *pDst);
 	int getNumTracks(void);
 	bool isTrackPlaying(int trk);
 	void masterGain(int gain);

--- a/wavTrigger.h
+++ b/wavTrigger.h
@@ -78,7 +78,7 @@
 
 
 #ifdef __WT_USE_ALTSOFTSERIAL__
-#include "../AltSoftSerial/AltSoftSerial.h"
+#include <AltSoftSerial.h>
 #else
 #include <HardwareSerial.h>
 #ifdef __WT_USE_SERIAL1__

--- a/wavTrigger.h
+++ b/wavTrigger.h
@@ -80,7 +80,11 @@
 #ifdef __WT_USE_ALTSOFTSERIAL__
 #include <AltSoftSerial.h>
 #else
+#if defined(__SAM3X8E__)
+#include <Arduino.h>
+#else
 #include <HardwareSerial.h>
+#endif
 #ifdef __WT_USE_SERIAL1__
 #define WTSerial Serial1
 #define __WT_SERIAL_ASSIGNED__

--- a/wavTrigger.h
+++ b/wavTrigger.h
@@ -80,7 +80,7 @@
 #ifdef __WT_USE_ALTSOFTSERIAL__
 #include <AltSoftSerial.h>
 #else
-#if defined(__SAM3X8E__)
+#ifdef __SAM3X8E__
 #include <Arduino.h>
 #else
 #include <HardwareSerial.h>


### PR DESCRIPTION
These changes resolve the compilation errors in the Arduino IDE by discarding an unnecessary variable from flush() and explicitly typecasting trk from int to uint16_t for the comparison operation in isTrackPlaying(int trk).

Additionally this PR corrects an out-of-bounds character array issue in the getVersion() function that was double-dipping the version character array cleaning process which was already handled sufficiently by update(). Resolves #28 

This PR also adds a define for the Arduino Due to include Arduino.h for serial ports rather than HardwareSerial.h, which Resolves #16 

Finally, this PR changes the hardcoded path to AltSoftSerial's header file to use the Arduino Library instead, which simplifies sketches and Resolves #18 