### PR TITLE
Change serial selection mechanism to allow for falling back

### DIFF
--- a/wavTrigger.h
+++ b/wavTrigger.h
@@ -34,10 +34,13 @@
 // The following defines are used to control which serial class is
 //  used. Uncomment only the one you wish to use. If all of them are
 //  commented out, the library will use Hardware Serial
-#define __WT_USE_ALTSOFTSERIAL__
+
 //#define __WT_USE_SERIAL1__
 //#define __WT_USE_SERIAL2__
 //#define __WT_USE_SERIAL3__
+#if !defined(__WT_USE_SERIAL1__) || !defined(__WT_USE_SERIAL2__) || !defined(__WT_USE_SERIAL3__)
+#define __WT_USE_ALTSOFTSERIAL__
+#endif
 // ==================================================================
 
 #define CMD_GET_VERSION					1

--- a/wavTrigger.h
+++ b/wavTrigger.h
@@ -33,7 +33,7 @@
 // ==================================================================
 // The following defines are used to control which serial class is
 //  used. Uncomment only the one you wish to use. If all of them are
-//  commented out, the library will use Hardware Serial
+//  commented out, the library will use Software Serial
 
 //#define __WT_USE_SERIAL1__
 //#define __WT_USE_SERIAL2__


### PR DESCRIPTION
If the macros for hardware serial aren't set, fall back to softserial. If any one of them are set, don't set the softserial macro and don't include the softserial lib.

This allows the user to set the macro to select the serial port within the sketch itself rather than having to edit the library itself. If the user does not do so, the library falls back onto software serial as a backup method.